### PR TITLE
Add root path invalidation if build/index.html is present

### DIFF
--- a/lib/middleman-cloudfront/commands.rb
+++ b/lib/middleman-cloudfront/commands.rb
@@ -83,6 +83,9 @@ module Middleman
             index_file_dirs = index_files.map { |f| f[%r((.+)index\.html\z), 1] }
             files.concat index_file_dirs
 
+            # Add root path if build/index.html is present
+            files.push '/' if files.include?('index.html') && !files.include?('/')
+
             # Add leading slash
             files.map! { |f| f.start_with?('/') ? f : "/#{f}" }
           end

--- a/spec/lib/middleman-cloudfront/commands_spec.rb
+++ b/spec/lib/middleman-cloudfront/commands_spec.rb
@@ -55,4 +55,21 @@ describe Middleman::Cli::CloudFront do
       end
     end
   end
+
+  describe '#list_files' do
+    before do
+      Dir.should_receive(:chdir).and_yield
+    end
+
+    it 'includes root path if build/index.html is present' do
+      Dir.stub(:glob).and_return(['.', 'index.html'])
+      expect( cloudfront.send(:list_files, /.*/) ).to eq(['/index.html', '/'])
+    end
+
+    it "doesn't include root path when build/index.html not present" do
+      Dir.stub(:glob).and_return(['.', 'test.html', 'test/index.html'])
+      expect( cloudfront.send(:list_files, /.*/) ).to eq(
+        ['/test.html', '/test/index.html', '/test/'])
+    end
+  end
 end


### PR DESCRIPTION
I found that the gem doesn't invalidate the root URL on CloudFront. For example, `http://example.com/index.html` would be invalidated but `http://example.com` would not.

So I updated the `#list_files` method to add the root path to the list of files to invalidate if the build/index.html file is present.
