### PR TITLE
Encode filenames

### DIFF
--- a/lib/middleman-cloudfront/commands.rb
+++ b/lib/middleman-cloudfront/commands.rb
@@ -55,7 +55,7 @@ end
         # CloudFront limits the amount of files which can be invalidated by one request to 1000.
         # If there are more than 1000 files to invalidate, do so sequentially and wait until each validation is ready.
         # If there are max 1000 files, create the invalidation and return immediately.
-        files = list_files(options.filter)
+        files = list_files(options.filter).map { |file| URI::encode(file) }
         return if files.empty?
 
         if files.count <= INVALIDATION_LIMIT


### PR DESCRIPTION
I had an error when trying to upload my files. This is the error:

```
<?xml version=\"1.0\"?>\n<ErrorResponse xmlns=\"http://cloudfront.amazonaws.com/doc/2010-11-01/\"><Error><Type>Sender</Type><Code>InvalidArgument</Code><Message>Your request contains one or more invalid invalidation paths.</Message></Error><RequestId>04705081-4e05-11e4-8882-43cbc738add4</RequestId></ErrorResponse>
```

I'm almost completely sure it's due to me having filenames with spaces in them.
