### PR TITLE
Note the removal of after_s3_sync in middleman-s3_sync v4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,3 @@ AWS_ACCESS_KEY= AWS_SECRET= bundle exec middleman sync
 AWS_ACCESS_KEY= AWS_SECRET= bundle exec middleman invalidate
 ```
 
-If you use [middleman-s3_sync](https://github.com/fredjean/middleman-s3_sync) for deployment, you can use its `after_s3_sync` hook to automatically invalidate updated files after syncing:
-```ruby
-after_s3_sync do |files_by_status|
-  invalidate files_by_status[:updated]
-end
-```

--- a/README.md
+++ b/README.md
@@ -109,3 +109,11 @@ AWS_ACCESS_KEY= AWS_SECRET= bundle exec middleman sync
 AWS_ACCESS_KEY= AWS_SECRET= bundle exec middleman invalidate
 ```
 
+If you use [middleman-s3_sync](https://github.com/fredjean/middleman-s3_sync) for deployment, you can use its `after_s3_sync` hook to automatically invalidate updated files after syncing:
+```ruby
+after_s3_sync do |files_by_status|
+  invalidate files_by_status[:updated]
+end
+```
+
+NOTE: The `after_s3_sync` hook only works with middleman-s3_sync v3.x and below. It has been [removed in v4.0](https://github.com/fredjean/middleman-s3_sync/blob/master/Changelog.md#v400).


### PR DESCRIPTION
Per the middleman-s3_sync changelog for version 4.0.0, the after_s3_sync hook has been removed since Middleman v4 no long supports hooks. https://github.com/fredjean/middleman-s3_sync/blob/master/Changelog.md#v400