### PR TITLE
Ruby 3 compatibility

### DIFF
--- a/lib/middleman-cloudfront/commands/invalidate.rb
+++ b/lib/middleman-cloudfront/commands/invalidate.rb
@@ -1,6 +1,7 @@
 require 'middleman-cli'
 require 'middleman-cloudfront/extension'
 require 'fog/aws'
+require 'addressable/uri'
 
 module Middleman
   module Cli
@@ -132,7 +133,7 @@ end
           end.uniq
 
           # URI encode and add leading slash
-          files.map { |f| URI::encode(f.start_with?('/') ? f : "/#{f}") }
+          files.map { |f| Addressable::URI::encode(f.start_with?('/') ? f : "/#{f}") }
         end
 
         # Add to CLI

--- a/middleman-cloudfront.gemspec
+++ b/middleman-cloudfront.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 0.9.0'
   s.add_development_dependency 'rspec', '~> 3.0'
 
+  s.add_dependency 'addressable', '>= 2.8.1'
   s.add_dependency 'fog-aws', '>= 0.1.1'
   s.add_dependency 'middleman-core', '>= 3.0'
   s.add_dependency 'middleman-cli', '>= 3.0'


### PR DESCRIPTION
Fixes an error when using `middleman invalidate` command in ruby 3.

```
.../lib/middleman-cloudfront/commands/invalidate.rb:135:in `block in normalize_files': undefined method `encode' for URI:Module (NoMethodError)
```

I did a bit of digging and found that the best option is to use the `addressable` gem for its implementation of `URI::encode`.

 I've successfully tested this on my own site with the proposed changes.